### PR TITLE
Patch: No S3 bucket

### DIFF
--- a/processImages.js
+++ b/processImages.js
@@ -1,7 +1,9 @@
 const request = require('request-promise')
 
 const config = require('./config')
-const { uploadImage } = require('./s3')
+if (config.s3Bucket) {
+  const { uploadImage } = require('./s3')
+}
 
 const replaceAll = (str, obj) => {
   let newStr = str


### PR DESCRIPTION
Make `processImages` also load if no S3 bucket is configured.

Without this fix, `processImages` does not load when no S3 bucket is configured, because `s3.js` trys to connect to AWS when loaded.